### PR TITLE
Fix(electron): Correct build configuration to prevent blank screen

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -16,7 +16,7 @@ function createWindow() {
     win.loadURL(
         isDev
             ? 'http://localhost:3000'
-            : `file://${path.join(__dirname, '../build/index.html')}`
+            : `file://${path.join(__dirname, 'index.html')}`
     );
 
     // Open the DevTools.


### PR DESCRIPTION
This commit addresses an issue where the packaged Electron application would display a blank screen instead of the React application.

The root cause was an incorrect configuration for the production build, which resulted in the main Electron process being unable to locate and load the `index.html` file of the React application.

The following changes were made:
- The `main` entry point in `package.json` was changed from `public/electron.js` to `build/electron.js`.
- The `build` script in `package.json` was updated to copy `public/electron.js` to the `build` directory after the React application is built.
- The `files` array in the `electron-builder` configuration in `package.json` was cleaned up to remove the `public` directory, which is not needed in the final package.
- The URL loading logic in `public/electron.js` was updated to correctly reference the `index.html` file from within the `build` directory in the production environment.

These changes align the project with the standard practices for packaging a Create React App-based Electron application.